### PR TITLE
Added check for empty action in template

### DIFF
--- a/src/Http/Controllers/TableAdminController.php
+++ b/src/Http/Controllers/TableAdminController.php
@@ -142,6 +142,10 @@ class TableAdminController extends Controller
         if (!isset($templates[$node->template])) {
             App::abort(404);
         }
+	    
+	if (empty($templates[$node->template]['action'])) {
+            App::abort(404);
+        }
 
         $def = $templates[$node->template]['node_definition'];
 


### PR DESCRIPTION
Abort application with 404 error whenever template has no defined action or it is set to false.
Without this change Tree node templates without action (e.g. sub-nodes that are shown as blocks on parent page) will throw either unknown index or undefined offset exceptions .