### PR TITLE
Load cache prefix from env file

### DIFF
--- a/src/install/files/cache.php
+++ b/src/install/files/cache.php
@@ -76,6 +76,6 @@ return [
     |
     */
 
-    'prefix' => 'laravel',
+    'prefix' => env('CACHE_PREFIX', 'laravel'),
 
 ];


### PR DESCRIPTION
Development and production project are supposed to have different cache prefix to prevent cache collision
Using env file for cache prefix will solve this problem